### PR TITLE
ignore /code dir, since README encourages its creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /code
+/dc-code-prototype


### PR DESCRIPTION
First thing that I wanted to do was ignore the /code directory, and this is how I did it.
