### PR TITLE
Update section._

### DIFF
--- a/templates/section._
+++ b/templates/section._
@@ -21,7 +21,6 @@
 
         <script>
             function search_box_submit() {
-                event.preventDefault();
                 var elem = document.getElementById("search-box")
                 var val = elem.value;
                 if (val.length == 0) return false;


### PR DESCRIPTION
Eliminate the `event.preventDefault();` line in the search box lets it work in Firefox and in Chrome. Because `return false` is already included, the first line is surplus anyway.
