### PR TITLE
Visual tweaks.

### DIFF
--- a/css/body.css
+++ b/css/body.css
@@ -18,8 +18,8 @@
         font-weight: bold;
         color: #666;
     }
-    
-    /* paragraphs can have multiple numbers when there are nested levels without intermediate 
+
+    /* paragraphs can have multiple numbers when there are nested levels without intermediate
        text, e.g. (3) (A) Blah blah. Only reverse-indent the first, otherwise the floats land
        on top of each other. */
     #content .level-num:first-child {
@@ -42,7 +42,7 @@
     }
 
 .primary-content {
-    padding: 0 .5em;
+    padding: 0;
 }
 
 .annotations {
@@ -78,8 +78,22 @@
     white-space: pre-wrap;
 }
 
+.line {
+    margin-top: 10px;
+}
+
+.line:first-child {
+    margin-top: 0;
+}
+
 .subheading {
     margin: 1em 0;
+}
+
+@media only screen and (max-width: 640px) {
+    .annotations .line {
+        padding-left: 0 !important;
+    }
 }
 
 .child-link.placeholder a {

--- a/css/site.css
+++ b/css/site.css
@@ -8,6 +8,21 @@ html, body {
     padding: 0;
 }
 
+body {
+    display: flex;
+    min-height: 100vh;
+    flex-direction: column;
+}
+
+.main {
+    flex: 1;
+}
+
+.container {
+    padding-left: 12px;
+    padding-right: 12px;
+}
+
 a {
     color: rgba(67,127,190,1);
     text-decoration: underline;
@@ -64,7 +79,7 @@ footer p {
 }
 
 #sidebar {
-    padding: 0 50px 0 1em;
+    padding: 0 50px 0 0;
     font-size: 13px;
 }
 
@@ -90,5 +105,16 @@ header .st-search-input {
     }
     #content {
         font-size: 14px;
+    }
+}
+
+@media only screen and (max-width: 640px) {
+    .container {
+        padding-left: 0;
+        padding-right: 0;
+    }
+    h1, h2, h3, h4, h5, h6, p, li {
+        padding-left: 12px;
+        padding-right: 12px;
     }
 }

--- a/templates/section._
+++ b/templates/section._
@@ -20,7 +20,7 @@
     <body>
             <header>
                 <div class="container">
-                <div class='right'>
+                <div class='right no-print'>
                     <form id='search-form'>
                         <form>
                             <input type="text" id="st-search-input" class="st-search-input" />
@@ -30,7 +30,7 @@
                 <h1 id='sitename'><a href='<%= rootdir %>'>Code of the District of Columbia (Unofficial)</a></h1>
             </div>
             </header>
-            <div class='container'>
+            <div class='main container'>
                 <div class='clearfix' style='width: 100%;'>
                     <div id='sidebar' class='col4 quiet'>
                         <% if (ancestors.length > 0) { %>
@@ -66,10 +66,12 @@
             <footer>
                 <div class='container center'>
                     <p>This is a fast, unofficial interface to the
-                    <a href='http://dccouncil.us/UnofficialDCCode'>Unofficial DC Code</a> by
-                    <a href='https://github.com/openlawdc'>openlawdc</a>.
-                    <a href='https://github.com/openlawdc/simple-generator/issues'>See a problem? Report an issue.</a>
-                    <a href='http://swiftype.com?ref=pb'>Search provided by Swiftype.</a>
+                        <a href='http://dccouncil.us/UnofficialDCCode'>Unofficial DC Code</a> by
+                        <a href='https://github.com/openlawdc'>openlawdc</a>.
+                    </p>
+                    <p>
+                        <a href='https://github.com/openlawdc/simple-generator/issues'>See a problem? Report an issue.</a>
+                        <a href='http://swiftype.com?ref=pb'>Search provided by Swiftype.</a>
                     </p>
                 </div>
             </footer>


### PR DESCRIPTION
Some tweaks.

CSS:
- Provide a consistent side margin on text elements when window width is below 640px.
- More consistent alignment of text elements in general
- Breathing room between lines.
- Remove left-side padding from annotations text when window-width is below 640px.
- Use flexbox to stick footer to the bottom of window.

Template:
- Don’t display search form on print.
- Break footer text.
